### PR TITLE
Allow the GB core to load .gbc roms

### DIFF
--- a/pkg/gb/Cores/budude2.GB/data.json
+++ b/pkg/gb/Cores/budude2.GB/data.json
@@ -7,7 +7,7 @@
         "id": 1,
         "required": true,
         "parameters": "0x109",
-        "extensions": ["gb"],
+        "extensions": ["gb", "gbc"],
         "address": "0x10000000"
       },
       {


### PR DESCRIPTION
Allows users to load `.gbc` roms with the GB core. Will allow for loading GB-compatible GBC ROMS in GB mode, or for weirdos who like being told that they can't load GBC ROMs that don't have GB compatibility.