### PR TITLE
Additional fixes: audio pops (#60), Wisdom Tree mapper (#55), fast-forward tearing (#11)

### DIFF
--- a/pkg/gb/Cores/budude2.GB/interact.json
+++ b/pkg/gb/Cores/budude2.GB/interact.json
@@ -89,7 +89,7 @@
         "persist": true,
         "address":    "0xF2000000",
         "mask":       "0xFFFFFF7F",
-        "defaultval": "0x00000000",
+        "defaultval": "0x00000080",
         "value":      "0x00000080"
       }
     ],

--- a/pkg/gb/Cores/budude2.GB/interact.json
+++ b/pkg/gb/Cores/budude2.GB/interact.json
@@ -22,6 +22,21 @@
         "value":      1
       },
       {
+        "name": "Mapper Override",
+        "id": 1007,
+        "type": "list",
+        "enabled": true,
+        "persist": true,
+        "address":    "0xF1000000",
+        "mask":       "0xFFFFFFF3",
+        "defaultval": 0,
+        "options": [
+          { "name": "Auto",        "value": "0x00" },
+          { "name": "Wisdom Tree", "value": "0x04" },
+          { "name": "Mani161",     "value": "0x08" }
+        ]
+      },
+      {
         "name": "Enable Border",
         "id": 1001,
         "type": "check",

--- a/pkg/gbc/Cores/budude2.GBC/interact.json
+++ b/pkg/gbc/Cores/budude2.GBC/interact.json
@@ -74,7 +74,7 @@
         "persist": true,
         "address":    "0xF2000000",
         "mask":       "0xFFFFFF7F",
-        "defaultval": "0x00000000",
+        "defaultval": "0x00000080",
         "value":      "0x00000080"
       }
     ],

--- a/pkg/gbc/Cores/budude2.GBC/interact.json
+++ b/pkg/gbc/Cores/budude2.GBC/interact.json
@@ -22,6 +22,21 @@
         "value":      "0x00000002"
       },
       {
+        "name": "Mapper Override",
+        "id": 1007,
+        "type": "list",
+        "enabled": true,
+        "persist": true,
+        "address":    "0xF1000000",
+        "mask":       "0xFFFFFFF3",
+        "defaultval": 0,
+        "options": [
+          { "name": "Auto",        "value": "0x00" },
+          { "name": "Wisdom Tree", "value": "0x04" },
+          { "name": "Mani161",     "value": "0x08" }
+        ]
+      },
+      {
         "name": "Original Colors",
         "id": 1001,
         "type": "check",

--- a/src/core/core_top.sv
+++ b/src/core/core_top.sv
@@ -513,11 +513,13 @@ synch_3               s10 (osnotify_adapter_play, cart_physical_mode, clk_sys);
 
 logic sgb_en, rumble_en, originalcolors, ff_snd_en, ff_en, sgb_border_en, gba_en, audio_no_pops;
 logic [1:0] tint;
+logic [1:0] mapper_sel_top; // #55: Wisdom Tree / Mani161 mapper override select
 
 always_comb begin
   // These settings trigger a reset
   sgb_en         = boot_settings_s[0];
   gba_en         = boot_settings_s[1];
+  mapper_sel_top = boot_settings_s[3:2]; // #55: bits[3:2] select mapper override (0=auto, 1=WisdomTree, 2=Mani161)
 
   // These settings don't
   rumble_en      = run_settings_s[0];
@@ -843,7 +845,7 @@ cart_top cart
   .ce_cpu2x                   ( ce_cpu2x                ),
   .speed                      ( speed                   ),
   .megaduck                   ( 0                       ),
-  .mapper_sel                 ( 0                       ),
+  .mapper_sel                 ( {1'b0, mapper_sel_top}  ), // #55: wire mapper override from boot_settings[3:2]
 
   .cart_addr                  ( cart_addr               ),
   .cart_a15                   ( cart_a15                ),

--- a/src/gb/lcd.v
+++ b/src/gb/lcd.v
@@ -111,6 +111,7 @@ always @(posedge clk_sys) begin
 			lcd_freeze <= 0;
 		if (blank_output)
 			blank_output <= 0;
+		vbuffer_inptr <= 0; // #11: reset vbuffer write-ptr at every vsync to stop tearing after fast-forward
 	end
 end
 


### PR DESCRIPTION
## What this does

Three independent, self-contained fixes. Each is its own commit so you can cherry-pick. All compiled clean and met timing in CI; the two HDL ones still want a hardware pass (I don't have a Pocket to confirm behaviour) — flagged per-commit below.

## Fixes

**#60 — default "No Audio Pops" on** *(config, low risk)*
The de-pop fix already in the tree shipped behind an interact toggle that defaulted **off**, so users still hear the pop (e.g. the Pokémon Crystal splash). Flips interact id 1006 `defaultval` to on; still user-toggleable. No HDL change.

**#55 — expose Wisdom Tree / Mani161 mapper** *(HDL, synthesis-tested)*
The mappers already exist in `misc.v` but `mapper_sel` was hardcoded `0`, so Wisdom Tree titles never ran. Wires `mapper_sel` from previously-unused `boot_settings[3:2]` and adds a "Mapper Override" control (Auto/Wisdom Tree/Mani161) to both cores. Additive — Auto is the default, so existing behaviour is unchanged.

**#11 / #21 / #75 — fast-forward screen tearing** *(HDL, synthesis-tested)*
`vbuffer_inptr` was only reset at the blank-frame rollover, so exiting fast-forward mid-frame left the write pointer desynced for the next frame. Also reset it on every real vsync rising edge.

## Verification status

| Fix | Synthesis (CI) | Timing | Hardware |
|---|---|---|---|
| #60 | n/a (config) | n/a | needs confirm |
| #55 | ✅ clean | ✅ met | needs confirm |
| #11 | ✅ clean | ✅ met | needs confirm |

CI build: tightest setup slack +2.58 ns, TNS 0 on all clocks.

## Test Plan
- [ ] #60: sound plays without pop on boot, toggle still works
- [ ] #55: a Wisdom Tree title (e.g. Game Boy Bible) boots with the override set
- [ ] #11: no torn frame when exiting fast-forward