### PR TITLE
Sgb cart fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,158 @@
 # Gameboy/Game Boy Color for Analogue Pocket
+
 Ported from the original core developed at https://github.com/MiSTer-devel/Gameboy_MiSTer
 
 Please report any issues encountered to this repo. Issues will be upstreamed as necessary.
 
 ## Installation
-To install the core, copy the `Assets`, `Cores`, and `Platform` folders over to the root of your SD card. Please note that Finder on macOS automatically _replaces_ folders, rather than merging them like Windows does, so you have to manually merge the folders.
 
-Place the GBC bios in `/Assets/gbc/common` named "gbc_bios.bin", the GB bios in `/Assets/gb/common` named "gb_bios.bin", and the SGB bios in `/Assets/gb/common` named "sgb_boot.bin".
+To install the core, copy the `Assets`, `Cores`, and `Platform` folders over to the root of your SD card. Please note that Finder on macOS automatically *replaces* folders, rather than merging them like Windows does, so you have to manually merge the folders.
 
+Place the GBC BIOS in `/Assets/gbc/common` named `gbc_bios.bin`, the GB BIOS in `/Assets/gb/common` named `gb_bios.bin`, and the SGB BIOS in `/Assets/gb/common` named `sgb_boot.bin`.
+
+## Build from Source
+
+The GB and GBC cores are built from the same Quartus project. Before compiling, the source must be configured for the desired target.
+
+### 1. Install the Correct Quartus Version
+
+Check `src/ap_core.qsf` for the `LAST_QUARTUS_VERSION` assignment:
+
+```text
+set_global_assignment -name LAST_QUARTUS_VERSION "..."
+```
+
+Install the corresponding version of Intel Quartus Prime. Cyclone V device support must also be installed, as the Analogue Pocket core FPGA is a Cyclone V device.
+
+Verify the Quartus command-line tools are available:
+
+```shell
+quartus_sh --version
+```
+
+If `quartus_sh` is not in your `PATH`, run it directly from the Quartus installation directory or add the Quartus `bin64` directory to your `PATH`.
+
+### 2. Select the GB or GBC Build
+
+Open:
+
+```text
+src/core/core_top.sv
+```
+
+Near the top of the file is the `isgbc` define:
+
+```systemverilog
+`define isgbc 0
+```
+
+Set this value according to the core you want to build:
+
+```text
+0 = Game Boy / Super Game Boy
+1 = Game Boy Color
+```
+
+For the Game Boy core:
+
+```systemverilog
+`define isgbc 0
+```
+
+For the Game Boy Color core:
+
+```systemverilog
+`define isgbc 1
+```
+
+This setting is important. Building with the wrong value will produce a valid FPGA bitstream for the wrong core configuration.
+
+### 3. Clean Previous Quartus Build Files (if they exist)
+
+When switching versions, branches, tags, or GB/GBC configurations, it is recommended to remove previous Quartus build output before compiling.
+
+`git clean` is the easiest way to clean up the repo for the next build. Make sure you save off the previously built `.rbf_r` before running.
+
+```bash
+git clean -fX -d
+```
+
+### 4. Compile the Core
+
+From the `src` directory, run:
+
+```shell
+quartus_sh --flow compile ap_core
+```
+
+After a successful build, Quartus will generate:
+
+```text
+src/output_files/ap_core.rbf
+```
+
+### 5. Convert the RBF for openFPGA
+
+Analogue Pocket openFPGA cores use an `.rbf_r` bitstream. The bits within each byte of the Quartus-generated `.rbf` must be reversed.
+
+One way to reverse the bits is to use Analogue's `pf-dev-tools` Python package:
+
+It can be installed with the following command:
+
+```shell
+pip install pf-dev-tools
+```
+
+Then convert the generated bitstream using:
+
+```shell
+pf reverse output_files/ap_core.rbf output_files/gb.rbf_r
+```
+
+for a Game Boy build, or:
+
+```shell
+pf reverse output_files/ap_core.rbf output_files/gbc.rbf_r
+```
+
+for a Game Boy Color build.
+
+### 6. Install the Compiled Bitstream
+
+For a Game Boy build, copy:
+
+```text
+output_files/gb.rbf_r
+```
+
+to:
+
+```text
+/Cores/budude2.GB/gb.rbf_r
+```
+
+on the Analogue Pocket SD card.
+
+For a Game Boy Color build, copy:
+
+```text
+output_files/gbc.rbf_r
+```
+
+to:
+
+```text
+/Cores/budude2.GBC/gbc.rbf_r
+```
 
 ## Usage
-ROMs should be placed in `/Assets/gbc/common`, and `/Assets/gb/common`
+
+ROMs should be placed in `/Assets/gbc/common`, and `/Assets/gb/common`.
 
 ## Features
 
 ### Supported
+
 * Real-Time Clock
 * Fastforward
 * Original Gameboy display modes
@@ -26,4 +164,5 @@ ROMs should be placed in `/Assets/gbc/common`, and `/Assets/gb/common`
 * External Cartridges
 
 ### In Progress
-¯\\_(ツ)_/¯
+
+¯\*(ツ)*/¯

--- a/pkg/gb/Cores/budude2.GB/core.json
+++ b/pkg/gb/Cores/budude2.GB/core.json
@@ -7,8 +7,8 @@
       "description": "Game Boy",
       "author": "budude2",
       "url": "https://github.com/budude2/openfpga-GBC",
-      "version": "1.4.0",
-      "date_release": "2026-04-12"
+      "version": "1.4.1",
+      "date_release": "2026-08-09"
     },
     "framework": {
       "target_product": "Analogue Pocket",

--- a/pkg/gbc/Cores/budude2.GBC/core.json
+++ b/pkg/gbc/Cores/budude2.GBC/core.json
@@ -7,8 +7,8 @@
       "description": "Game Boy Color",
       "author": "budude2",
       "url": "https://github.com/budude2/openfpga-GBC",
-      "version": "1.4.0",
-      "date_release": "2026-04-12"
+      "version": "1.4.1",
+      "date_release": "2026-08-09"
     },
     "framework": {
       "target_product": "Analogue Pocket",

--- a/src/core/core_top.sv
+++ b/src/core/core_top.sv
@@ -1,6 +1,6 @@
 `default_nettype none
 
-`define isgbc 1
+`define isgbc 0
 
 module core_top (
 
@@ -1162,7 +1162,7 @@ sgb sgb (
   .joy_p54            ( joy_p54                       ),
   .joy_do             ( joy_do_sgb                    ),
 
-  .sgb_en             ( sgb_en & isSGB_game & ~isGBC  ),
+  .sgb_en             ( sgb_en & (isSGB_game | cart_physical_mode) & ~isGBC ),
   .tint               ( tint[1] & ~bw_en              ),
   .isGBC_game         ( isGBC & isGBC_game            ),
 


### PR DESCRIPTION
adds one line fix for using external carts with sgb graphics.

updates readme to describe manual build from source process

bump version to 1.4.1